### PR TITLE
Added more checks on RSA modules and fixed some error messages.

### DIFF
--- a/TumbleBitSetup/PermutationTest/Implementation/PermutationTest.cs
+++ b/TumbleBitSetup/PermutationTest/Implementation/PermutationTest.cs
@@ -42,10 +42,6 @@ namespace TumbleBitSetup
             // if N >= 2^{KeySize}
             if (Modulus.CompareTo(upperLimit) >= 0)
                 throw new ArgumentOutOfRangeException("RSA modulus larger than expected");
-            
-            // if even
-            if ((Modulus.IntValue & 1) == 0) // TODO: verify that this test does what is expected (I took it from BC)
-                throw new ArgumentException("RSA modulus is even");
 
             // Verify alpha and N
             if (!CheckAlphaN(alpha, Modulus))
@@ -118,10 +114,6 @@ namespace TumbleBitSetup
 
             // if N >= 2^{KeySize}
             if (Modulus.CompareTo(upperLimit) >= 0)
-                return false;
-
-            // if even
-            if ((Modulus.IntValue & 1) == 0) // TODO: verify that this test does what is expected (I took it from BC)
                 return false;
 
             // Generate m1 and m2

--- a/TumbleBitSetup/PermutationTest/Implementation/PermutationTest.cs
+++ b/TumbleBitSetup/PermutationTest/Implementation/PermutationTest.cs
@@ -24,11 +24,35 @@ namespace TumbleBitSetup
             BigInteger p = privKey.P;
             BigInteger q = privKey.Q;
             BigInteger e = privKey.PublicExponent;
-            BigInteger N = privKey.Modulus;
+            BigInteger Modulus = privKey.Modulus;
 
-            int alpha = setup.Alpha;
-            byte[] psBytes = setup.PublicString;
-            int k = setup.SecurityParameter;
+            var keyLength = Modulus.BitLength;
+            var alpha = setup.Alpha;
+
+            BigInteger Two = BigInteger.Two;
+            // 2^{|N| - 1}
+            BigInteger lowerLimit = Two.Pow(keyLength - 1);
+            // 2^{|N|}
+            BigInteger upperLimit = Two.Pow(keyLength);
+
+            // if N < 2^{KeySize-1}
+            if (Modulus.CompareTo(lowerLimit) < 0)
+                throw new ArgumentOutOfRangeException("RSA modulus smaller than expected");
+
+            // if N >= 2^{KeySize}
+            if (Modulus.CompareTo(upperLimit) >= 0)
+                throw new ArgumentOutOfRangeException("RSA modulus larger than expected");
+            
+            // if even
+            if ((Modulus.IntValue & 1) == 0) // TODO: verify that this test does what is expected (I took it from BC)
+                throw new ArgumentException("RSA modulus is even");
+
+            // Verify alpha and N
+            if (!CheckAlphaN(alpha, Modulus))
+                throw new ArgumentException("RSA modulus has a small prime factor");
+
+            var psBytes = setup.PublicString;
+            var k = setup.SecurityParameter;
 
             byte[][] sigs;
 
@@ -36,7 +60,7 @@ namespace TumbleBitSetup
             Get_m1_m2((decimal)alpha, e.IntValue, k, out int m1, out int m2);
 
             // Calculate eN
-            var eN = N.Multiply(e);
+            var eN = Modulus.Multiply(e);
 
             // Generate a pair (pub, sec) of keys with eN as e.
             var keyPrimePair = Utils.GeneratePrivate(p, q, eN);
@@ -45,7 +69,7 @@ namespace TumbleBitSetup
             var pubKey = privKey.ToPublicKey();
 
             // Generate list of rho values
-            GetRhos(m2, psBytes, pubKey, N.BitLength, out byte[][] rhoValues);
+            GetRhos(m2, psBytes, pubKey, keyLength, out byte[][] rhoValues);
 
             // Signing the Rho values
             sigs = new byte[m2][];
@@ -79,14 +103,14 @@ namespace TumbleBitSetup
             byte[] psBytes = setup.PublicString;
             int k = setup.SecurityParameter;
 
+            BigInteger Modulus = pubKey.Modulus;
+            BigInteger Exponent = pubKey.Exponent;
+
             BigInteger Two = BigInteger.Two;
             // 2^{|N| - 1}
             BigInteger lowerLimit = Two.Pow(keyLength - 1);
             // 2^{|N|}
             BigInteger upperLimit = Two.Pow(keyLength);
-
-            BigInteger Modulus = pubKey.Modulus;
-            BigInteger Exponent = pubKey.Exponent;
 
             // if N < 2^{KeySize-1}
             if (Modulus.CompareTo(lowerLimit) < 0)
@@ -94,6 +118,10 @@ namespace TumbleBitSetup
 
             // if N >= 2^{KeySize}
             if (Modulus.CompareTo(upperLimit) >= 0)
+                return false;
+
+            // if even
+            if ((Modulus.IntValue & 1) == 0) // TODO: verify that this test does what is expected (I took it from BC)
                 return false;
 
             // Generate m1 and m2

--- a/TumbleBitSetup/PoupardStern/Implementation/PoupardStern.cs
+++ b/TumbleBitSetup/PoupardStern/Implementation/PoupardStern.cs
@@ -46,7 +46,7 @@ namespace TumbleBitSetup
                 throw new ArgumentOutOfRangeException("RSA modulus larger than expected");
 
             // if even
-            if ((Modulus.IntValue & 1) == 0) // TODO: verify that this test does what is expected (I took it from BC)
+            if ((Modulus.IntValue & 1) == 0)
                 throw new ArgumentException("RSA modulus is even");
 
             // p and q don't produce a modulus N that has the expected bitLength
@@ -64,7 +64,7 @@ namespace TumbleBitSetup
             var p11 = Two.Pow(k);
             var p1 = lowerLimit.Divide(NsubPhi.Multiply(p11));
             if (p1.CompareTo(p11) <= 0)
-                throw new ArgumentOutOfRangeException("Bad RSA modulus N");
+                throw new ArgumentOutOfRangeException(nameof(Modulus), "Bad RSA modulus N");
 
             // Generate K
             GetK(k, out int BigK);
@@ -152,7 +152,7 @@ namespace TumbleBitSetup
             if (Modulus.CompareTo(lowerLimit) < 0)
                 return false;
             // if even
-            if ((Modulus.IntValue & 1) == 0) // TODO: verify that this test does what is expected (I took it from BC)
+            if ((Modulus.IntValue & 1) == 0)
                 return false;
             // if N >= 2^{KeySize}
             if (Modulus.CompareTo(upperLimit) >= 0)


### PR DESCRIPTION
Here are the checks I added for each algorithm:

**PermutationTest**:
  - **Proving function** (if true, then throw an exception):
    - Added N >= 2^|N|
    - Added N < 2^|N-1|
    - ~~Added N is Even~~
    - Added !CheckAlphaN(alpha, N) (GCD of N with primes up to and not including alpha)
  - **Verification function** (if true, then return false):
    - ~~Added N is Even.~~

**PoupardStern**:
  - **Proving function** (if true, then throw an exception):
    - Added N is Even
  - **Verification function** (if true, then return false):
    - Added N is Even

Here's how I propose the proving function should be used (I will modify the unit tests accordingly, but I'll verify it first):
```
while(true){
  Try{
    key = new RSAkey(~);
    proof = Prove(key);
  }catch(Exception){
    Continue;
  }
  Break;
}
```
